### PR TITLE
:arrow_up: Don't lock symfony/polyfill-mbstring on v1.20.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-json": "*",
         "spatie/laravel-sitemap": "^5.8",
         "nwidart/laravel-modules": "^8.0",
-        "symfony/polyfill-mbstring": "1.20.*"
+        "symfony/polyfill-mbstring": "^1.20.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",


### PR DESCRIPTION
Màj pour que la dépendance `symfony/polyfill-mbstring` puisse continuer à recevoir les mises à jour mineures 