### PR TITLE
:bug: Prevent from showing lang in email

### DIFF
--- a/src/Modules/Form/Http/Controllers/FormController.php
+++ b/src/Modules/Form/Http/Controllers/FormController.php
@@ -56,7 +56,7 @@ class FormController extends BaseController
 
         $files = !empty($request->file) ? $request->file : null;
 
-        $fields = Arr::except($request->post(),['valid_from', 'form_id', 'file', 'confirmation_email_name', 'extra']);
+        $fields = Arr::except($request->post(), ['valid_from', 'form_id', 'file', 'confirmation_email_name', 'extra']);
 
         Mail::to($to ?? config('mail.from.address'))->send(new SendForm($fields, $files));
 


### PR DESCRIPTION
Avec `$request->except()` on affiche toutes les infos contenues dans la requête, donc la langue aussi (qui est dans la route)

Si on ne veut récupérer que les champs dans le corps de la requête, il faut qu'on utilise `$request->post()`

La langue s'affiche comme ça dans l'email actuellement : 
<img width="152" alt="Screenshot 2021-03-23 à 16 30 25" src="https://user-images.githubusercontent.com/12596207/112172585-204b8280-8bf5-11eb-9fec-2d0dce57ae93.png">
