### PR TITLE
:bug: Handle arrays in extra form data

### DIFF
--- a/src/app/helpers.php
+++ b/src/app/helpers.php
@@ -77,7 +77,7 @@ if (!function_exists('has_zone_menu')) {
      */
     function has_zone_menu($zone): bool
     {
-        $menus =  app()->make(\Webid\Cms\App\Repositories\Menu\MenuRepository::class);
+        $menus = app()->make(\Webid\Cms\App\Repositories\Menu\MenuRepository::class);
 
         return $menus->menuZoneExist($zone);
     }
@@ -129,5 +129,12 @@ if (!function_exists('media_full_url')) {
         $file_path = ltrim($file_path, '/');
 
         return config('cms.image_path') . $file_path;
+    }
+}
+
+if (!function_exists('arrayKeysAreLocales')) {
+    function arrayKeysAreLocales(array $parameter): bool
+    {
+        return !empty(array_intersect_key(config('translatable.locales'), $parameter));
     }
 }


### PR DESCRIPTION
Le soucis vient du fait que dans les form_extra on peut avoir ça : 
```php
[
    "email_content" => "<p>...</p>",
    // ...
]
```
comme on peut avoir ça :
```php
[
    "email_content" => [
        "fr" => "<p>...</p>",
    ],
    // ...
]
```

La différence vient du fait que parfois on récupère des données traduisibles depuis l'attribut d'un model (donc `$model->attr` renvoie la string traduite), et parfois ça vient de données un peu plus complexes depuis Nova (des trucs imbriqués dynamiquement etc) et ça devient compliqué de faire en sorte de toujours récupérer la string traduite :/